### PR TITLE
Backport CVE patches

### DIFF
--- a/SOURCES/net-snmp-5.7.2-CVE-2022-24806.patch
+++ b/SOURCES/net-snmp-5.7.2-CVE-2022-24806.patch
@@ -1,0 +1,40 @@
+From df7533052991f49704e5550c4cd2d965c4927813 Mon Sep 17 00:00:00 2001
+From: Bill Fenner <fenner@gmail.com>
+Date: Tue, 24 Aug 2021 07:55:00 -0700
+Subject: [PATCH] CHANGES: snmpd: recover SET status from delegated request
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Reported by: Yu Zhang of VARAS@IIE, Nanyu Zhong of VARAS@IIE
+Fixes by: Arista Networks
+
+When a SET request includes a mix of delegated and
+non-delegated requests (e.g., objects handled by master
+agent and agentx sub-agent), the status can get lost while
+waiting for the reply from the sub-agent.  Recover the status
+into the session from the requests even if it has already
+been processed.
+---
+ agent/snmp_agent.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Backport notes:
+ upstream commit 9a0cd7c00947d5e1c6ceb54558d454f87c3b8341
+ Backported-By: Thierry Escande <thierry.escande@vates.tech>
+
+diff --git a/agent/snmp_agent.c b/agent/snmp_agent.c
+index b84060d..8579bf1 100644
+--- a/agent/snmp_agent.c
++++ b/agent/snmp_agent.c
+@@ -2643,7 +2643,7 @@ netsnmp_check_requests_status(netsnmp_agent_session *asp,
+         if (requests->status != SNMP_ERR_NOERROR &&
+             (!look_for_specific || requests->status == look_for_specific)
+             && (look_for_specific || asp->index == 0
+-                || requests->index < asp->index)) {
++                || requests->index <= asp->index)) {
+             asp->index = requests->index;
+             asp->status = requests->status;
+         }
+-- 
+2.43.0
+

--- a/SOURCES/net-snmp-5.7.2-CVE-2022-44793-1.patch
+++ b/SOURCES/net-snmp-5.7.2-CVE-2022-44793-1.patch
@@ -1,0 +1,67 @@
+From 5e525865a8091143c351c8faa4cf8d2ebd4024dd Mon Sep 17 00:00:00 2001
+From: Bill Fenner <fenner@gmail.com>
+Date: Fri, 25 Nov 2022 08:41:24 -0800
+Subject: [PATCH] snmp_agent: disallow SET with NULL varbind
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+---
+ agent/snmp_agent.c | 32 ++++++++++++++++++++++++++++++++
+ 1 file changed, 32 insertions(+)
+
+Backport notes:
+ upstream commit 4589352dac3ae111c7621298cf231742209efd9b
+ Backported-By: Thierry Escande <thierry.escande@vates.tech>
+
+diff --git a/agent/snmp_agent.c b/agent/snmp_agent.c
+index 8579bf1..6f5d24e 100644
+--- a/agent/snmp_agent.c
++++ b/agent/snmp_agent.c
+@@ -3340,12 +3340,44 @@ netsnmp_handle_request(netsnmp_agent_session *asp, int status)
+     return 1;
+ }
+ 
++static int
++check_set_pdu_for_null_varbind(netsnmp_agent_session *asp)
++{
++    int i;
++    netsnmp_variable_list *v = NULL;
++
++    for (i = 1, v = asp->pdu->variables; v != NULL; i++, v = v->next_variable) {
++	if (v->type == ASN_NULL) {
++	    /*
++	     * Protect SET implementations that do not protect themselves
++	     * against wrong type.
++	     */
++	    DEBUGMSGTL(("snmp_agent", "disallowing SET with NULL var for varbind %d\n", i));
++	    asp->index = i;
++	    return SNMP_ERR_WRONGTYPE;
++	}
++    }
++    return SNMP_ERR_NOERROR;
++}
++
+ int
+ handle_pdu(netsnmp_agent_session *asp)
+ {
+     int             status, inclusives = 0;
+     netsnmp_variable_list *v = NULL;
+ 
++#ifndef NETSNMP_NO_WRITE_SUPPORT
++    /*
++     * Check for ASN_NULL in SET request
++     */
++    if (asp->pdu->command == SNMP_MSG_SET) {
++	status = check_set_pdu_for_null_varbind(asp);
++	if (status != SNMP_ERR_NOERROR) {
++	    return status;
++	}
++    }
++#endif /* NETSNMP_NO_WRITE_SUPPORT */
++
+     /*
+      * for illegal requests, mark all nodes as ASN_NULL 
+      */
+-- 
+2.43.0
+

--- a/SOURCES/net-snmp-5.7.2-CVE-2022-44793-2.patch
+++ b/SOURCES/net-snmp-5.7.2-CVE-2022-44793-2.patch
@@ -1,0 +1,30 @@
+From 937ecf76a24bc2ed3d4a713d8d0f0027a0233f28 Mon Sep 17 00:00:00 2001
+From: Bill Fenner <fenner@gmail.com>
+Date: Fri, 25 Nov 2022 08:41:46 -0800
+Subject: [PATCH] apps: snmpset: allow SET with NULL varbind for testing
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+---
+ apps/snmpset.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+Backport notes:
+ upstream commit 7f4ac4051cc7fec6a5944661923acb95cec359c7
+ Backported-By: Thierry Escande <thierry.escande@vates.tech>
+
+diff --git a/apps/snmpset.c b/apps/snmpset.c
+index 1b29a6c..0229c3c 100644
+--- a/apps/snmpset.c
++++ b/apps/snmpset.c
+@@ -179,6 +179,7 @@ main(int argc, char *argv[])
+             case 'x':
+             case 'd':
+             case 'b':
++            case 'n': /* undocumented */
+ #ifdef NETSNMP_WITH_OPAQUE_SPECIAL_TYPES
+             case 'I':
+             case 'U':
+-- 
+2.43.0
+

--- a/SOURCES/net-snmp-5.7.2-CVE-2022-44793-3.patch
+++ b/SOURCES/net-snmp-5.7.2-CVE-2022-44793-3.patch
@@ -1,0 +1,56 @@
+From 7fa22c2002ff283cb1e5845cc53160032d9a8435 Mon Sep 17 00:00:00 2001
+From: Bill Fenner <fenner@gmail.com>
+Date: Fri, 25 Nov 2022 10:23:32 -0800
+Subject: [PATCH] Add test for NULL varbind set
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+---
+ .../default/T0142snmpv2csetnull_simple        | 31 +++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+ create mode 100644 testing/fulltests/default/T0142snmpv2csetnull_simple
+
+Backport notes:
+ upstream commit 15f9d7f7e5b90c9b419832ed8e6413feb6570d83
+ Backported-By: Thierry Escande <thierry.escande@vates.tech>
+
+diff --git a/testing/fulltests/default/T0142snmpv2csetnull_simple b/testing/fulltests/default/T0142snmpv2csetnull_simple
+new file mode 100644
+index 0000000..0f1b8f3
+--- /dev/null
++++ b/testing/fulltests/default/T0142snmpv2csetnull_simple
+@@ -0,0 +1,31 @@
++#!/bin/sh
++
++. ../support/simple_eval_tools.sh
++
++HEADER SNMPv2c set of system.sysContact.0 with NULL varbind
++
++SKIPIF NETSNMP_DISABLE_SET_SUPPORT
++SKIPIF NETSNMP_NO_WRITE_SUPPORT
++SKIPIF NETSNMP_DISABLE_SNMPV2C
++SKIPIFNOT USING_MIBII_SYSTEM_MIB_MODULE
++
++#
++# Begin test
++#
++
++# standard V2C configuration: testcomunnity
++snmp_write_access='all'
++. ./Sv2cconfig
++STARTAGENT
++
++CAPTURE "snmpget -On $SNMP_FLAGS -c testcommunity -v 2c $SNMP_TRANSPORT_SPEC:$SNMP_TEST_DEST$SNMP_SNMPD_PORT .1.3.6.1.2.1.1.4.0"
++
++CHECK ".1.3.6.1.2.1.1.4.0 = STRING:"
++
++CAPTURE "snmpset -On $SNMP_FLAGS -c testcommunity -v 2c $SNMP_TRANSPORT_SPEC:$SNMP_TEST_DEST$SNMP_SNMPD_PORT .1.3.6.1.2.1.1.4.0 n x"
++
++CHECK "Reason: wrongType"
++
++STOPAGENT
++
++FINISHED
+-- 
+2.43.0
+

--- a/SOURCES/net-snmp-5.7.2-CVEs-2022-24805-24807-24808-24809-24810.patch
+++ b/SOURCES/net-snmp-5.7.2-CVEs-2022-24805-24807-24808-24809-24810.patch
@@ -1,0 +1,140 @@
+From e1ebd571892e38bb3ddb52c76b81404dab66fe19 Mon Sep 17 00:00:00 2001
+From: Bill Fenner <fenner@gmail.com>
+Date: Wed, 30 Jun 2021 14:00:28 -0700
+Subject: [PATCH] CHANGES: snmpd: fix bounds checking in NET-SNMP-AGENT-MIB,
+ NET-SNMP-VACM-MIB, SNMP-VIEW-BASED-ACM-MIB, SNMP-USER-BASED-SM-MIB
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Reported by: Yu Zhang of VARAS@IIE, Nanyu Zhong of VARAS@IIE
+Fixes by: Arista Networks
+---
+ agent/mibgroup/agent/nsLogging.c         |  6 ++++++
+ agent/mibgroup/agent/nsVacmAccessTable.c | 16 ++++++++++++++--
+ agent/mibgroup/mibII/vacm_vars.c         |  3 +++
+ agent/mibgroup/snmpv3/usmUser.c          |  2 --
+ 4 files changed, 23 insertions(+), 4 deletions(-)
+
+Backport notes:
+ upstream commit 67ebb43e9038b2dae6e74ae8838b36fcc10fc937
+ Backported-By: Thierry Escande <thierry.escande@vates.tech>
+
+diff --git a/agent/mibgroup/agent/nsLogging.c b/agent/mibgroup/agent/nsLogging.c
+index 7f20bdb..0953d80 100644
+--- a/agent/mibgroup/agent/nsLogging.c
++++ b/agent/mibgroup/agent/nsLogging.c
+@@ -146,6 +146,8 @@ handle_nsLoggingTable(netsnmp_mib_handler *handler,
+                 continue;
+             logh = (netsnmp_log_handler*)netsnmp_extract_iterator_context(request);
+             table_info  =                netsnmp_extract_table_info(request);
++            if (!table_info || !table_info->indexes)
++                continue;
+ 
+             switch (table_info->colnum) {
+             case NSLOGGING_TYPE:
+@@ -200,6 +202,8 @@ handle_nsLoggingTable(netsnmp_mib_handler *handler,
+             }
+             logh = (netsnmp_log_handler*)netsnmp_extract_iterator_context(request);
+             table_info  =                 netsnmp_extract_table_info(request);
++            if (!table_info || !table_info->indexes)
++                continue;
+ 
+             switch (table_info->colnum) {
+             case NSLOGGING_TYPE:
+@@ -393,6 +397,8 @@ handle_nsLoggingTable(netsnmp_mib_handler *handler,
+                 continue;
+             logh = (netsnmp_log_handler*)netsnmp_extract_iterator_context(request);
+             table_info  =                 netsnmp_extract_table_info(request);
++            if (!table_info || !table_info->indexes)
++                continue;
+ 
+             switch (table_info->colnum) {
+             case NSLOGGING_TYPE:
+diff --git a/agent/mibgroup/agent/nsVacmAccessTable.c b/agent/mibgroup/agent/nsVacmAccessTable.c
+index 79fa97d..dae56fe 100644
+--- a/agent/mibgroup/agent/nsVacmAccessTable.c
++++ b/agent/mibgroup/agent/nsVacmAccessTable.c
+@@ -170,9 +170,13 @@ nsVacmAccessTable_handler(netsnmp_mib_handler *handler,
+             entry = (struct vacm_accessEntry *)
+                 netsnmp_extract_iterator_context(request);
+             table_info = netsnmp_extract_table_info(request);
++            if (!table_info || !table_info->indexes)
++                continue;
+ 
+             /* Extract the authType token from the list of indexes */
+             idx = table_info->indexes->next_variable->next_variable->next_variable->next_variable;
++            if (idx->val_len >= sizeof(atype))
++                continue;
+             memset(atype, 0, sizeof(atype));
+             memcpy(atype, (char *)idx->val.string, idx->val_len);
+             viewIdx = se_find_value_in_slist(VACM_VIEW_ENUM_NAME, atype);
+@@ -212,6 +216,8 @@ nsVacmAccessTable_handler(netsnmp_mib_handler *handler,
+             entry = (struct vacm_accessEntry *)
+                 netsnmp_extract_iterator_context(request);
+             table_info = netsnmp_extract_table_info(request);
++            if (!table_info || !table_info->indexes)
++                continue;
+             ret = SNMP_ERR_NOERROR;
+ 
+             switch (table_info->colnum) {
+@@ -247,6 +253,8 @@ nsVacmAccessTable_handler(netsnmp_mib_handler *handler,
+                  * Extract the authType token from the list of indexes
+                  */
+                 idx = table_info->indexes->next_variable->next_variable->next_variable->next_variable;
++                if (idx->val_len >= sizeof(atype))
++                    continue;
+                 memset(atype, 0, sizeof(atype));
+                 memcpy(atype, (char *)idx->val.string, idx->val_len);
+                 viewIdx = se_find_value_in_slist(VACM_VIEW_ENUM_NAME, atype);
+@@ -294,8 +302,10 @@ nsVacmAccessTable_handler(netsnmp_mib_handler *handler,
+                          idx = idx->next_variable;  model = *idx->val.integer;
+                          idx = idx->next_variable;  level = *idx->val.integer;
+                          entry = vacm_createAccessEntry( gName, cPrefix, model, level );
+-                         entry->storageType = ST_NONVOLATILE;
+-                         netsnmp_insert_iterator_context(request, (void*)entry);
++                         if (entry) {
++                             entry->storageType = ST_NONVOLATILE;
++                             netsnmp_insert_iterator_context(request, (void*)entry);
++                         }
+                     }
+                 }
+             }
+@@ -321,6 +331,8 @@ nsVacmAccessTable_handler(netsnmp_mib_handler *handler,
+ 
+             /* Extract the authType token from the list of indexes */
+             idx = table_info->indexes->next_variable->next_variable->next_variable->next_variable;
++            if (idx->val_len >= sizeof(atype))
++                continue;
+             memset(atype, 0, sizeof(atype));
+             memcpy(atype, (char *)idx->val.string, idx->val_len);
+             viewIdx = se_find_value_in_slist(VACM_VIEW_ENUM_NAME, atype);
+diff --git a/agent/mibgroup/mibII/vacm_vars.c b/agent/mibgroup/mibII/vacm_vars.c
+index 85cef94..cc36113 100644
+--- a/agent/mibgroup/mibII/vacm_vars.c
++++ b/agent/mibgroup/mibII/vacm_vars.c
+@@ -989,6 +989,9 @@ access_parse_oid(oid * oidIndex, size_t oidLen,
+         return 1;
+     }
+     groupNameL = oidIndex[0];
++    if ((groupNameL + 1) > (int) oidLen) {
++        return 1;
++    }
+     contextPrefixL = oidIndex[groupNameL + 1];  /* the initial name length */
+     if ((int) oidLen != groupNameL + contextPrefixL + 4) {
+         return 1;
+diff --git a/agent/mibgroup/snmpv3/usmUser.c b/agent/mibgroup/snmpv3/usmUser.c
+index 41c525a..d68eeb4 100644
+--- a/agent/mibgroup/snmpv3/usmUser.c
++++ b/agent/mibgroup/snmpv3/usmUser.c
+@@ -1447,8 +1447,6 @@ write_usmUserStatus(int action,
+                 if (usmStatusCheck(uptr)) {
+                     uptr->userStatus = RS_ACTIVE;
+                 } else {
+-                    SNMP_FREE(engineID);
+-                    SNMP_FREE(newName);
+                     return SNMP_ERR_INCONSISTENTVALUE;
+                 }
+             } else if (long_ret == RS_CREATEANDWAIT) {
+-- 
+2.43.0
+

--- a/SPECS/net-snmp.spec
+++ b/SPECS/net-snmp.spec
@@ -9,7 +9,7 @@
 Summary: A collection of SNMP protocol tools and libraries
 Name: net-snmp
 Version: 5.7.2
-Release: %{?xsrel}.2%{?dist}
+Release: %{?xsrel}.3%{?dist}
 Epoch: 1
 License: BSD
 Group: System Environment/Daemons
@@ -122,6 +122,11 @@ Patch90: net-snmp-5.7.2-bulk.patch
 
 # XCP-ng patches
 Source100: net-snmp-5.7.2-no-XENSERVER-MIB.xcp-ng.patch
+Patch1000: net-snmp-5.7.2-CVEs-2022-24805-24807-24808-24809-24810.patch
+Patch1001: net-snmp-5.7.2-CVE-2022-24806.patch
+Patch1002: net-snmp-5.7.2-CVE-2022-44793-1.patch
+Patch1003: net-snmp-5.7.2-CVE-2022-44793-2.patch
+Patch1004: net-snmp-5.7.2-CVE-2022-44793-3.patch
 
 Requires(post): chkconfig
 Requires(preun): chkconfig
@@ -529,6 +534,10 @@ rm -rf ${RPM_BUILD_ROOT}
 
 
 %changelog
+* Mon Aug 12 2024 Thierry Escande <thierry.escande@vates.tech> - 5.7.2-51.3
+- Backport patches for CVE-2022-24805, CVE-2022-24806, CVE-2022-24807,
+  CVE-2022-24808, CVE-2022-24809, CVE-2022-24810, and CVE-2022-44793
+
 * Fri Jul 05 2024 Samuel Verschelde <stormi-xcp@ylix.fr> - 5.7.2-51.2
 - Add net-snmp-5.7.2-no-XENSERVER-MIB.xcp-ng.patch
 - Remove XenServer-specific options from /etc/sysconfig/snmpd


### PR DESCRIPTION
This backports upstream patches for CVE-2022-24805, CVE-2022-24806, CVE-2022-24807, CVE-2022-24808, CVE-2022-24809, CVE-2022-24810, and CVE-2022-44793.

All upstream patches applied cleanly with only minor index changes.