### PR TITLE
Fix snmpd config patching on install

### DIFF
--- a/SPECS/net-snmp.spec
+++ b/SPECS/net-snmp.spec
@@ -15,7 +15,7 @@
 Summary:    A collection of SNMP protocol tools and libraries
 Name:       net-snmp
 Version:    5.9.3
-Release:    %{?xsrel}.1%{?dist}
+Release:    %{?xsrel}.2%{?dist}
 %if 0%{?xenserver} < 9
 Epoch:      1
 %global     epoch_str %{epoch}:
@@ -261,7 +261,7 @@ install -m 644 %SOURCE11 %{buildroot}%{_sysconfdir}/snmp/snmpd.xs.conf
 install -d %{buildroot}%{_sysconfdir}/sysconfig
 
 # XCP-ng: patch /etc/sysconfig/snmpd
-cp %SOURCE7 net-snmpd.sysconfig
+cp %{_sourcedir}/net-snmpd.sysconfig .
 patch -p1 < %SOURCE100
 install -m 644 net-snmpd.sysconfig ${RPM_BUILD_ROOT}%{_sysconfdir}/sysconfig/snmpd
 rm -f net-snmpd.sysconfig
@@ -417,6 +417,9 @@ LD_LIBRARY_PATH=%{buildroot}/%{_libdir} make test
 %{_libdir}/libnetsnmptrapd*.so.%{soname}*
 
 %changelog
+* Mon Mar 23 2026 Philippe Coval <philippe.coval@vates.tech> - 5.9.3-8.2
+- Fix snmpd config patching on install
+
 * Thu Jan 22 2026 Philippe Coval <philippe.coval@vates.tech> - 5.9.3-8.1
 - Rebuild for openssl-3
 - Remove obsolete net-snmp-5.7.2-CVE-2022-24806.patch


### PR DESCRIPTION
Fix snmpd config patching on install

It was reported that config file was broken in lastest update of
XCP-ng 8.3.0-37.

The cause is that source file was renamed (7 to 5) in the serie, so it
should have been renamed later in the recipe too (which is not
breaking at build time).

To prevent future issues, the actual source's filename is now used.



For history, check affected lines (diff) of file /etc/sysconfig/snmpd:

From net-snmp-5.7.2-52.1.xcpng8.3.x86_64 (xcp-ng-8.3.0-20250606.iso)

    +# snmpd command line options
    +# '-f' is implicitly added by snmpd systemd unit file
    +# OPTIONS="-LS0-6d"
    +OPTIONS="-c /etc/snmp/snmpd.xs.conf"

From net-snmp-5.9.3-8.1.xcpng8.3.x86_64:

    -# snmpd command line options
    -# '-f' is implicitly added by snmpd systemd unit file
    -# OPTIONS="-LS0-6d"
    -OPTIONS="-c /etc/snmp/snmpd.xs.conf"
    +d      /run/net-snmp   0755    root    root

Bug is here ^. config is meaningless.

So this change reverts back to original conf:

    -d      /run/net-snmp   0755    root    root
    +# snmpd command line options
    +# '-f' is implicitly added by snmpd systemd unit file
    +# OPTIONS="-LS0-6d"
    +OPTIONS="-c /etc/snmp/snmpd.xs.conf"


Merge remote-tracking branch XS-8.3' into 8.3 (catchup)

The XS branch was not merged back, let me do again after merge to 8.3,
because it may needs a fix.


# TODO 

- [ ] Double check compare to upstream / xs branches and older version

Thanks-to: https://xcp-ng.org/forum/user/flibbi
